### PR TITLE
Update the links to 'riot' by it's new name 'element'

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Instance (new): https://fretsboard.herokuapp.com
 
 Instance (old): http://fretsonfire.sourceforge.net/charts/
 
-Get in touch (via matrix): [#fretsboard:matrix.org](https://riot.im/app/#/room/#fretsboard:matrix.org)
+Get in touch (via matrix): [#fretsboard:matrix.org](https://app.element.io/#/room/#fretsboard:matrix.org)
 
 
 ![Screenshot scoreboard](https://raw.githubusercontent.com/Linkid/fretsboard/master/docs/source/_static/screenhsot_scoreboard.png "Screenshot scoreboard")

--- a/templates/base.html
+++ b/templates/base.html
@@ -84,7 +84,7 @@
                 <a href="https://github.com/Linkid/fretsboard"><i class="fab fa-github fa-2x" title="{% trans 'Code / GitHub' %}"></i></a>
               </li>
               <li class="list-inline-item">
-                <a href="https://riot.im/app/#/room/#fretsboard:matrix.org"><i class="fas fa-comments fa-2x" title="{% trans 'Chat / Matrix' %}"></i></a>
+                <a href="https://app.element.io/#/room/#fretsboard:matrix.org"><i class="fas fa-comments fa-2x" title="{% trans 'Chat / Matrix' %}"></i></a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
Riot was renamed to Element. This PR updates the links where riot appears,
so they stay coherent with the service's name. Fix #24