### PR TITLE
Change dependency from m2r to m2r2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-m2r
+m2r2
 sphinx
 sphinx_rtd_theme

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@ sys.path.insert(0, os.path.abspath('../../scoreboard'))
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'm2r',
+    'm2r2',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
To build the doc, the dependency to m2r is obsolete. The maintained version is m2r2.